### PR TITLE
dnf/main python3.11 3.11.15 1.amzn2023.0.4

### DIFF
--- a/aws-cli/Dockerfile
+++ b/aws-cli/Dockerfile
@@ -33,7 +33,7 @@ RUN dnf upgrade -y \
     pwgen-2.08-11.amzn2023 \
     python3-3.9.25-1.amzn2023.0.3 \
     python3-pip-21.3.1-2.amzn2023.0.16 \
-    python3.11-3.11.14-1.amzn2023.0.5 \
+    python3.11-3.11.15-1.amzn2023.0.4 \
     python3.11-pip-22.3.1-2.amzn2023.0.10 \
     python3.12-3.12.12-2.amzn2023.0.4 \
     python3.12-pip-23.2.1-4.amzn2023.0.7 \


### PR DESCRIPTION
- **ci(zizmor): allow leplusorg actions**
- **build(deps): bump python3.11 from 3.11.14-1.amzn2023.0.5 to 3.11.15-1.amzn2023.0.4**
