### PR TITLE
dnf/main python3.12 3.12.13 2.amzn2023.0.4

### DIFF
--- a/aws-cli/Dockerfile
+++ b/aws-cli/Dockerfile
@@ -35,7 +35,7 @@ RUN dnf upgrade -y \
     python3-pip-21.3.1-2.amzn2023.0.16 \
     python3.11-3.11.14-1.amzn2023.0.5 \
     python3.11-pip-22.3.1-2.amzn2023.0.10 \
-    python3.12-3.12.12-2.amzn2023.0.4 \
+    python3.12-3.12.13-2.amzn2023.0.4 \
     python3.12-pip-23.2.1-4.amzn2023.0.7 \
     python3.13-3.13.12-1.amzn2023.0.1 \
     python3.13-pip-24.2-259.amzn2023.0.4 \


### PR DESCRIPTION
- **ci(zizmor): allow leplusorg actions**
- **build(deps): bump python3.12 from 3.12.12-2.amzn2023.0.4 to 3.12.13-2.amzn2023.0.4**
