### PR TITLE
dnf/main python3.14 3.14.6 1.amzn2023.0.2

### DIFF
--- a/aws-cli/Dockerfile
+++ b/aws-cli/Dockerfile
@@ -39,7 +39,7 @@ RUN dnf upgrade -y \
     python3.12-pip-23.2.1-4.amzn2023.0.7 \
     python3.13-3.13.12-1.amzn2023.0.1 \
     python3.13-pip-24.2-259.amzn2023.0.4 \
-    python3.14-3.14.2-2.amzn2023.0.3 \
+    python3.14-3.14.6-1.amzn2023.0.2 \
     python3.14-pip-25.1.1-1.amzn2023.0.1 \
     rsync-3.4.0-1.amzn2023.0.3 \
     sed-4.8-7.amzn2023.0.2 \


### PR DESCRIPTION
- **ci(zizmor): allow leplusorg actions**
- **build(deps): bump python3.14 from 3.14.2-2.amzn2023.0.3 to 3.14.6-1.amzn2023.0.2**
